### PR TITLE
Rework status information: 0 to 100 for blinds / new exact position reading / regularly updated state

### DIFF
--- a/10_SOMFY.pm
+++ b/10_SOMFY.pm
@@ -6,14 +6,6 @@
 #
 # Needs CULFW V 1.59 or higher (support for "Y" command).
 #
-######################################################
-# $Id: 10_SOMFY.pm 7988 2015-02-14 22:04:45Z thomyd $
-#
-# SOMFY RTS / Simu Hz protocol module for FHEM
-# (c) Thomas Dankert <post@thomyd.de>
-#
-# Needs CULFW V 1.59 or higher (support for "Y" command).
-#
 # Published under GNU GPL License, v2
 #
 # History:

--- a/10_SOMFY.pm
+++ b/10_SOMFY.pm
@@ -30,7 +30,7 @@
 #	1.5		thomyd			Bugfix for wrong attribute names when calculating the updatetime (drive-up-...)
 #
 #	1.5jv	viegener		New state and action handling (trying to stay compatible also adding virtual receiver capabilities)
-#									state/position are now regularly updated during longer moves (as specified in somfy_updateFreq in seconds)
+#									2015-04-30 - state/position are now regularly updated during longer moves (as specified in somfy_updateFreq in seconds)
 #
 
 #
@@ -849,6 +849,7 @@ sub SOMFY_InternalSet($@) {
 		InternalTimer(gettimeofday()+$utime,"SOMFY_TimedUpdate",$hash,0);
 	} else {
 		delete $hash->{runningtime};
+		delete $hash->{starttime};
 	}
 
 	return undef;

--- a/10_SOMFY.pm
+++ b/10_SOMFY.pm
@@ -100,7 +100,7 @@ my $somfy_posAccuracy = 5;
 my $somfy_maxRuntime = 50;
 
 my %positions = (
-	"middle" => "50",  
+	"moving" => "50",  
 	"open" => "0", 
 	"off" => "0", 
 	"closed" => "200", 
@@ -645,34 +645,34 @@ sub SOMFY_InternalSet($@) {
 		#if timings not set 
 
 		if($cmd eq 'on') {
-			$newState = 'middle';
+			$newState = 'moving';
 			$updatetime = $somfy_maxRuntime;
 			$updateState = 'closed';
 		} elsif($cmd eq 'off') {
-			$newState = 'middle';
+			$newState = 'moving';
 			$updatetime = $somfy_maxRuntime;
 			$updateState = 'open';
 
 		} elsif($cmd eq 'on-for-timer') {
 			# elsif cmd == on-for-timer - time x
 			$move = 'on';
-			$newState = 'middle';
+			$newState = 'moving';
 			$drivetime = $arg1;
 			if ( $drivetime == 0 ) {
 				$move = 'stop';
 			} else {
-				$updateState = 'middle';
+				$updateState = 'moving';
 			}
 
 		} elsif($cmd eq 'off-for-timer') {
 			# elsif cmd == off-for-timer - time x
 			$move = 'off';
-			$newState = 'middle';
+			$newState = 'moving';
 			$drivetime = $arg1;
 			if ( $drivetime == 0 ) {
 				$move = 'stop';
 			} else {
-				$updateState = 'middle';
+				$updateState = 'moving';
 			}
 
 		} elsif($cmd =~m/stop|go_my/) { 
@@ -977,8 +977,8 @@ sub SOMFY_CalcCurrentPos($$$$) {
 			Log3($name,1,"SOMFY_CalcCurrentPos: $name move wrong $move");
 		}			
 	} else {
-		### no timings set so just assume it is always middle
-		$newPos = $positions{'middle'};
+		### no timings set so just assume it is always moving
+		$newPos = $positions{'moving'};
 	}
 	
 	return $newPos;

--- a/10_SOMFY.pm
+++ b/10_SOMFY.pm
@@ -29,7 +29,8 @@
 #
 #	1.5		thomyd			Bugfix for wrong attribute names when calculating the updatetime (drive-up-...)
 #
-#	1.5jv	viegener		New state and action handling (trying to stay compatible also adding virtual receiver capabilities)
+#	1.6	viegener		New state and action handling (trying to stay compatible also adding virtual receiver capabilities)
+#									Further refined:
 #									2015-04-30 - state/position are now regularly updated during longer moves (as specified in somfy_updateFreq in seconds)
 #									2015-04-30 - For blinds normalize on pos 0 to 100 (max) (meaning if drive-down-time-to-close == drive-down-time-to-100 and drive-up-time-to-100 == 0)
 #         				2015-04-30 - new reading exact position called 'exact' also used for further pos calculations

--- a/10_SOMFY.pm
+++ b/10_SOMFY.pm
@@ -32,15 +32,10 @@
 #	1.5jv	viegener		New state and action handling (trying to stay compatible also adding virtual receiver capabilities)
 #
 
-### test paths ???? not yet finished
 #
-# test - all somfy commands for blinds without timings set
+######################################################
 #
-# issue - position was above 200 in a case --> might be resolved ?
-# issue - is numeric state really ok ?
-#
-### Open ??? - if timer is running and last command equals new command (only for open / close) - considered minor/but still relevant
-### Open ??? - adapt documentation (where needed)
+### Known Issue - if timer is running and last command equals new command (only for open / close) - considered minor/but still relevant
 
 ######################################################
 

--- a/10_SOMFY.pm
+++ b/10_SOMFY.pm
@@ -11,25 +11,26 @@
 # History:
 #	1.0		thomyd			initial implementation
 #
-#	1.1		Elektrolurch	state changed to open,close,pos <x>
+#	1.1		Elektrolurch		state changed to open,close,pos <x>
 # 							for using "set device pos <value> the attributes
 #							drive-down-time-to-100, drive-down-time-to-close,
 #							drive-up-time-to-100 and drive-up-time-to-open must be set
 # 							Hardware section seperated to SOMFY_SetCommand
 #
-#	1.2		Elektrolurch	state is now set after reaching the position of the blind
+#	1.2		Elektrolurch		state is now set after reaching the position of the blind
 #							preparation for receiving signals of Somfy remotes signals,
 #							associated with the blind
 #
 #	1.3		thomyd			Basic implementation of "parse" function, requires updated CULFW
 #							Removed open/close as the same functionality can be achieved with an eventMap.
 #
-#	1.4 	thomyd			Implemented fallback on/off-for-timer methods and only show warning about stop/go-my
+#	1.4 		thomyd			Implemented fallback on/off-for-timer methods and only show warning about stop/go-my
 #							if the positioning attributes are set.
 #
 #	1.5		thomyd			Bugfix for wrong attribute names when calculating the updatetime (drive-up-...)
 #
-#	1.6	viegener		New state and action handling (trying to stay compatible also adding virtual receiver capabilities)
+#	1.6		viegener		New state and action handling (trying to stay compatible also adding virtual receiver capabilities)
+#
 #									Further refined:
 #									2015-04-30 - state/position are now regularly updated during longer moves (as specified in somfy_updateFreq in seconds)
 #									2015-04-30 - For blinds normalize on pos 0 to 100 (max) (meaning if drive-down-time-to-close == drive-down-time-to-100 and drive-up-time-to-100 == 0)
@@ -573,6 +574,16 @@ sub SOMFY_InternalSet($@) {
 	return "SOMFY_set: No set value specified" if ( $numberOfArgs < 1 );
 
 	my $cmd = lc($args[0]);
+
+	# just a number provided, assume "pos" command
+	if ($cmd =~ m/\d{1,3}/) {
+		pop @args;
+		push @args, "pos";
+		push @args, $cmd;
+
+		$cmd = "pos";
+		$numberOfArgs = int(@args);
+	}
 
 	if(!exists($sets{$cmd})) {
 		my @cList;

--- a/10_SOMFY.pm
+++ b/10_SOMFY.pm
@@ -31,7 +31,8 @@
 #
 #	1.5jv	viegener		New state and action handling (trying to stay compatible also adding virtual receiver capabilities)
 #									2015-04-30 - state/position are now regularly updated during longer moves (as specified in somfy_updateFreq in seconds)
-#
+#									2015-04-30 - For markisen normalize on pos 0 to 100 (max) (meaning if drive-down-time-to-close == drive-down-time-to-100 and same for up times)
+
 
 #
 ######################################################
@@ -40,7 +41,6 @@
 
 # Somfy Modul - TODO
 # - 100 bis 200% besser --> 100% / down/ complete
-# - if position is reached already, just sent command and update state (down in % 200 / up in 0%)
 # - if drive-down-time-to-close == drive-down-time-to-100 --> go only to 100
 
 
@@ -794,8 +794,14 @@ sub SOMFY_InternalSet($@) {
 			}
 
 		}			
+
+		## special case close is at 100 ("markisen")
+		if( ( $t1downclose == $t1down100) && ( $t1upopen == $t1up100) ) {
+			$updateState = min( 100, $updateState );
+			$newState = min( 100, $posRounded );
+		}
 	}
-	
+
 	### update hash / readings
 	Log3($name,5,"SOMFY_set: handled command $cmd --> move :$move:  newState :$newState: ");
 	if ( defined($updateState)) {


### PR DESCRIPTION
renaming state "middle" to "moving" 
state/position are now regularly updated during longer moves
   (as specified in somfy_updateFreq in seconds)
For markisen/blinds normalize on pos 0 to 100 (max) 
   (meaning if drive-down-time-to-close == drive-down-time-to-100 and same for up times)
new exact position reading 'exact' 
also documentation adopted